### PR TITLE
EVCPO-10 - adapt transactions to run & stop properly with driivz

### DIFF
--- a/payload/ocpp20/build.gradle
+++ b/payload/ocpp20/build.gradle
@@ -71,7 +71,6 @@ apply plugin: 'jsonschema2pojo'
 
 jsonSchema2Pojo {
 //    source = files("${sourceSets.main.output.resourcesDir}/schemas/v20/json")
-//    source = files("${sourceSets.main.output.resourcesDir}/schemas/v201/json")
     source = files("${sourceSets.main.output.resourcesDir}/schemas/v201")
     targetPackage = "com.evbox.everon.ocpp.v20.message"
 }

--- a/sample-configuration.yml
+++ b/sample-configuration.yml
@@ -8,10 +8,10 @@ stations:
         basicAuthPassword: FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
       txCtrlr:
         evConnectionTimeOutSec: 120
-        txStartPoints:
+        txStartPoint:
           - EVConnected
           - Authorized
-        txStopPoints:
+        txStopPoint:
           - Authorized
   - id: EVB-P18090564
     evse:

--- a/simulator-core/build.gradle
+++ b/simulator-core/build.gradle
@@ -40,7 +40,8 @@ lombok {
 }
 
 dependencies {
-    compile 'io.everon:ocpp-payload:2.0.1.0'
+//    compile 'io.everon:ocpp-payload:2.0.1.0'
+    compile project(':payload:ocpp20')
 
     compile 'info.picocli:picocli:3.9.2'
     compile 'com.squareup.okhttp3:okhttp:3.12.1'

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/SimulatorConfiguration.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/configuration/SimulatorConfiguration.java
@@ -17,8 +17,28 @@ public class SimulatorConfiguration {
     private static final int DEFAULT_HEARTBEAT_INTERVAL = 60;
 
     private static final int DEFAULT_EV_CONNECTION_TIMEOUT = 60;
-    private static final List<String> DEFAULT_TX_START_POINTS = Arrays.asList(TxStartStopPointVariableValues.AUTHORIZED.toString(), TxStartStopPointVariableValues.EV_CONNECTED.toString());
-    private static final List<String> DEFAULT_TX_STOP_POINTS = Arrays.asList(TxStartStopPointVariableValues.AUTHORIZED.toString(), TxStartStopPointVariableValues.EV_CONNECTED.toString());
+    private static final List<String> DEFAULT_TX_START_POINTS =
+            Arrays.asList(
+                    TxStartStopPointVariableValues.AUTHORIZED.toString(),
+                    TxStartStopPointVariableValues.EV_CONNECTED.toString()
+            );
+    private static final List<String> DEFAULT_TX_START_POINTS_OCPP_1_6 =
+            Arrays.asList(
+                    TxStartStopPointVariableValues.POWER_PATH_CLOSED.toString(),
+                    TxStartStopPointVariableValues.ENERGY_TRANSFER.toString()
+            );
+    private static final List<String> DEFAULT_TX_STOP_POINTS =
+            Arrays.asList(
+                    TxStartStopPointVariableValues.AUTHORIZED.toString(),
+                    TxStartStopPointVariableValues.EV_CONNECTED.toString()
+            );
+    private static final List<String> DEFAULT_TX_STOP_POINTS_OCCP_1_6 =
+            Arrays.asList(
+                    TxStartStopPointVariableValues.AUTHORIZED.toString(),
+                    TxStartStopPointVariableValues.EV_CONNECTED.toString(),
+                    TxStartStopPointVariableValues.DATA_SIGNED.toString(),
+                    TxStartStopPointVariableValues.POWER_PATH_CLOSED.toString()
+            );
 
     private static final long DEFAULT_SEND_METER_VALUES_INTERVAL_SEC = 10;
     private static final long DEFAULT_CONSUMPTION_WATT_HOUR = 22_000;
@@ -125,13 +145,13 @@ public class SimulatorConfiguration {
          * List of events that defines when a new transaction should start.
          */
         @Builder.Default
-        private List<String> txStartPoints = DEFAULT_TX_START_POINTS;
+        private List<String> txStartPoint = DEFAULT_TX_START_POINTS;
 
         /**
          * List of events that when no longer valid, the transaction should be ended.
          */
         @Builder.Default
-        private List<String> txStopPoints = DEFAULT_TX_STOP_POINTS;
+        private List<String> txStopPoint = DEFAULT_TX_STOP_POINTS;
     }
 
     @Data

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/PayloadFactory.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/PayloadFactory.java
@@ -191,7 +191,7 @@ public class PayloadFactory {
         SampledValue sampledValue = new SampledValue()
 //                .withSignedMeterValue(createSignedMeterValues(stationId, eventType, powerConsumed))
                 .withValue(getPowerConsumed(stationId, eventType, powerConsumed))
-                                        .withMeasurand(MeasurandEnum.ENERGY_ACTIVE_IMPORT_REGISTER);
+                .withMeasurand(MeasurandEnum.ENERGY_ACTIVE_IMPORT_REGISTER);
 
         if(STARTED.equals(eventType)) {
             sampledValue.withContext(ReadingContextEnum.TRANSACTION_BEGIN);

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/Station.java
@@ -116,8 +116,9 @@ public class Station {
         }
 
         new MeterValuesScheduler(state, stationMessageSender, meterValuesConfiguration.getSendMeterValuesIntervalSec(), meterValuesConfiguration.getConsumptionWattHour());
-        new PeriodicEventScheduler(stationMessageSender);
-        new AlertEventScheduler(stationMessageSender);
+// TODO check why it doesn't work
+//        new PeriodicEventScheduler(stationMessageSender);
+//        new AlertEventScheduler(stationMessageSender);
 
         this.stateManager = new StateManager(this, state, stationMessageSender);
     }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationMessageSender.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationMessageSender.java
@@ -165,18 +165,6 @@ public class StationMessageSender {
      * @param connectorId   connector identity
      * @param reason        reason why it was triggered
      * @param chargingState charging state of the station
-     */
-    public void sendTransactionEventUpdate(Integer evseId, Integer connectorId, TriggerReasonEnum reason, ChargingStateEnum chargingState) {
-        sendTransactionEventUpdate(evseId, connectorId, reason, chargingState, null);
-    }
-
-    /**
-     * Send TransactionEventUpdate event.
-     *
-     * @param evseId        evse identity
-     * @param connectorId   connector identity
-     * @param reason        reason why it was triggered
-     * @param chargingState charging state of the station
      * @param powerConsumed power consumed by the evse
      */
     public void sendTransactionEventUpdate(Integer evseId, Integer connectorId, TriggerReasonEnum reason, ChargingStateEnum chargingState, Long powerConsumed) {

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationStore.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/StationStore.java
@@ -62,8 +62,8 @@ public class StationStore {
         this.stationId = configuration.getId();
         this.evses = initEvses(configuration.getEvse().getCount(), configuration.getEvse().getConnectors(), configuration.getEvse().getStatus());
         this.evConnectionTimeOut = configuration.getComponentsConfiguration().getTxCtrlr().getEvConnectionTimeOutSec();
-        this.txStartPointValues = new OptionList<>(TxStartStopPointVariableValues.fromValues(configuration.getComponentsConfiguration().getTxCtrlr().getTxStartPoints()));
-        this.txStopPointValues = new OptionList<>(TxStartStopPointVariableValues.fromValues(configuration.getComponentsConfiguration().getTxCtrlr().getTxStopPoints()));
+        this.txStartPointValues = new OptionList<>(TxStartStopPointVariableValues.fromValues(configuration.getComponentsConfiguration().getTxCtrlr().getTxStartPoint()));
+        this.txStopPointValues = new OptionList<>(TxStartStopPointVariableValues.fromValues(configuration.getComponentsConfiguration().getTxCtrlr().getTxStopPoint()));
     }
 
     public StationStore(Clock clock, int heartbeatInterval, int evConnectionTimeOut, Map<Integer, Evse> evses) {

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/transactionctrlr/TxStartPointVariableAccessor.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/transactionctrlr/TxStartPointVariableAccessor.java
@@ -29,7 +29,7 @@ import static java.util.Collections.singletonList;
 
 public class TxStartPointVariableAccessor extends VariableAccessor {
 
-    public static final String NAME = "TxStartPoints";
+    public static final String NAME = "TxStartPoint";
     private final Map<AttributeType, VariableGetter> variableGetters = ImmutableMap.<AttributeType, VariableGetter>builder()
             .put(AttributeType.ACTUAL, this::getActualValue)
             .build();

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/transactionctrlr/TxStartStopPointVariableValues.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/transactionctrlr/TxStartStopPointVariableValues.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 public enum TxStartStopPointVariableValues {
 
+    PARKING_BAY_OCCUPANCY("ParkingBayOccupancy"),
     EV_CONNECTED("EVConnected"),
     AUTHORIZED("Authorized"),
     DATA_SIGNED("DataSigned"),

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/transactionctrlr/TxStopPointVariableAccessor.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/component/transactionctrlr/TxStopPointVariableAccessor.java
@@ -29,7 +29,7 @@ import static java.util.Collections.singletonList;
 
 public class TxStopPointVariableAccessor extends VariableAccessor {
 
-    public static final String NAME = "TxStopPoints";
+    public static final String NAME = "TxStopPoint";
     private final Map<AttributeType, VariableGetter> variableGetters = ImmutableMap.<AttributeType, VariableGetter>builder()
             .put(AttributeType.ACTUAL, this::getActualValue)
             .build();

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/Evse.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/Evse.java
@@ -52,13 +52,13 @@ public class Evse {
     private EvseStatus scheduledNewEvseStatus;
 
     /**
-     *  Total power consumed by the evse in watt hour
+     * Total power consumed by the evse in watt hour
      */
     private long totalConsumedWattHours;
 
 
     /**
-     *  Current state of the evse
+     * Current state of the evse
      */
     private AbstractEvseState evseState;
 
@@ -155,6 +155,7 @@ public class Evse {
 
     /**
      * Getter for the current evse state.
+     *
      * @return evseState
      */
     public AbstractEvseState getEvseState() {
@@ -163,6 +164,7 @@ public class Evse {
 
     /**
      * Sets the current state of the evse.
+     *
      * @param evseState new state fro the evse
      */
     public void setEvseState(AbstractEvseState evseState) {
@@ -291,7 +293,6 @@ public class Evse {
      * Find any LOCKED connector and switch to PLUGGED status.
      *
      * @return identity of the connector.
-     *
      */
     public Integer unlockConnector() {
 
@@ -344,6 +345,7 @@ public class Evse {
                 .filter(connector -> ConnectorStatusEnum.AVAILABLE.equals(connector.getConnectorStatus()))
                 .findAny();
     }
+
     /**
      * Find an instance of a plugged {@link Connector}.
      *
@@ -368,6 +370,11 @@ public class Evse {
                 .orElseThrow(() -> new IllegalArgumentException(String.format("No connector with ID: %s", connectorId)));
     }
 
+    public long incrementPowerConsumedAndGetUsedPowerForCurrentCharging(long incrementValue) {
+        incrementPowerConsumed(incrementValue);
+        return getWattConsumedLastSession();
+    }
+
     /**
      * Increases the power consumed by the value specified.
      * If the new value exceeds MAX_VALUE then it will restart from 0.
@@ -375,14 +382,13 @@ public class Evse {
      * @param incrementValue amount of power to add to the consumed power
      * @return updated value of consumed power
      */
-    public long incrementPowerConsumed(long incrementValue) {
+    private void incrementPowerConsumed(long incrementValue) {
         long diff = Long.MAX_VALUE - totalConsumedWattHours;
         if (incrementValue > diff) {
             totalConsumedWattHours = incrementValue - diff - 1;
         } else {
             totalConsumedWattHours += incrementValue;
         }
-        return totalConsumedWattHours;
     }
 
     @Override
@@ -396,6 +402,7 @@ public class Evse {
                 ", transaction=" + transaction +
                 ", evseStatus=" + evseStatus +
                 ", totalConsumedWattHours=" + totalConsumedWattHours +
+                ", stateName=" + evseState +
                 '}';
     }
 
@@ -413,6 +420,7 @@ public class Evse {
                 .transaction(transaction.createView())
                 .scheduledNewEvseStatus(scheduledNewEvseStatus)
                 .totalConsumedWattHours(totalConsumedWattHours)
+                .evseState(evseState.getStateName())
                 .build();
     }
 
@@ -437,6 +445,7 @@ public class Evse {
         private final EvseTransactionView transaction;
         private final EvseStatus scheduledNewEvseStatus;
         private final long totalConsumedWattHours;
+        private final String evseState;
 
         /**
          * Checks whether EVSE has a token or not.

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/AvailableState.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/AvailableState.java
@@ -55,7 +55,7 @@ public class AvailableState extends AbstractEvseState {
         stationMessageSender.sendStatusNotificationAndSubscribe(evse, evse.findConnector(connectorId), (statusNotificationRequest, statusNotificationResponse) -> {
             OptionList<TxStartStopPointVariableValues> startPoints = stateManager.getStationStore().getTxStartPointValues();
             if (startPoints.contains(TxStartStopPointVariableValues.EV_CONNECTED) && !startPoints.contains(TxStartStopPointVariableValues.POWER_PATH_CLOSED)) {
-                String transactionId = TransactionIdGenerator.getInstance().getAndIncrement();
+                String transactionId = TransactionIdGenerator.getInstance().generateTransactionId();
                 evse.createTransaction(transactionId);
 
                 stationMessageSender.sendTransactionEventStart(evseId, connectorId, TriggerReasonEnum.CABLE_PLUGGED_IN, ChargingStateEnum.EV_CONNECTED);
@@ -84,7 +84,7 @@ public class AvailableState extends AbstractEvseState {
 
                 OptionList<TxStartStopPointVariableValues> startPoints = stationStore.getTxStartPointValues();
                 if (startPoints.contains(TxStartStopPointVariableValues.AUTHORIZED) && !startPoints.contains(TxStartStopPointVariableValues.POWER_PATH_CLOSED)) {
-                    String transactionId = TransactionIdGenerator.getInstance().getAndIncrement();
+                    String transactionId = TransactionIdGenerator.getInstance().generateTransactionId();
                     authorizedEvses.forEach(evse -> evse.createTransaction(transactionId));
 
                     authorizedEvses.forEach(evse -> stationMessageSender.sendTransactionEventStart(evse.getId(), TriggerReasonEnum.AUTHORIZED, tokenId));
@@ -112,7 +112,7 @@ public class AvailableState extends AbstractEvseState {
 
         Evse evse = stationStore.findEvse(evseId);
 
-        String transactionId = TransactionIdGenerator.getInstance().getAndIncrement();
+        String transactionId = TransactionIdGenerator.getInstance().generateTransactionId();
         evse.createTransaction(transactionId);
 
         evse.setToken(tokenId);

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/ChargingState.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/ChargingState.java
@@ -112,7 +112,7 @@ public class ChargingState extends AbstractEvseState {
 
         evse.stopCharging();
         Integer connectorId = evse.tryUnlockConnector();
-        stationMessageSender.sendTransactionEventUpdate(evseId, connectorId, REMOTE_STOP, ChargingStateEnum.EV_CONNECTED);
+        stationMessageSender.sendTransactionEventUpdate(evseId, connectorId, REMOTE_STOP, ChargingStateEnum.EV_CONNECTED, evse.getWattConsumedLastSession());
 
         stateManager.setStateForEvse(evseId, new RemotelyStoppedState());
     }
@@ -120,7 +120,7 @@ public class ChargingState extends AbstractEvseState {
     private int stopCharging(StationMessageSender stationMessageSender, Evse evse) {
         evse.stopCharging();
         Integer connectorId = evse.unlockConnector();
-        stationMessageSender.sendTransactionEventUpdate(evse.getId(), connectorId, STOP_AUTHORIZED, ChargingStateEnum.EV_CONNECTED);
+        stationMessageSender.sendTransactionEventUpdate(evse.getId(), connectorId, STOP_AUTHORIZED, ChargingStateEnum.EV_CONNECTED, evse.getWattConsumedLastSession());
         return connectorId;
     }
 

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/RemotelyStoppedState.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/RemotelyStoppedState.java
@@ -28,11 +28,20 @@ public class RemotelyStoppedState extends StoppedState {
         evse.stopTransaction();
         evse.clearToken();
 
-        stationMessageSender.sendStatusNotification(evse, evse.findConnector(connectorId));
-        stationMessageSender.sendTransactionEventEnded(evseId, connectorId,
-                                                        TriggerReasonEnum.EV_DEPARTED,
-                                                        ReasonEnum.REMOTE,
-                                                        evse.getWattConsumedLastSession());
+//        stationMessageSender.sendStatusNotification(evse, evse.findConnector(connectorId));
+//        stationMessageSender.sendTransactionEventEnded(evseId, connectorId,
+//                                                        TriggerReasonEnum.EV_DEPARTED,
+//                                                        ReasonEnum.REMOTE,
+//                                                        evse.getWattConsumedLastSession());
+
+        stationMessageSender.sendTransactionEventEndedAndSubscribe(evseId, connectorId,
+                TriggerReasonEnum.EV_DEPARTED,
+                ReasonEnum.REMOTE,
+                evse.getWattConsumedLastSession(),
+                (request, response) -> {
+                    stationMessageSender.sendStatusNotification(evse, evse.findConnector(connectorId));
+                });
+
 
         stateManager.setStateForEvse(evseId, new AvailableState());
         return CompletableFuture.completedFuture(UserMessageResult.SUCCESSFUL);

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/StoppedState.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/StoppedState.java
@@ -87,7 +87,7 @@ public class StoppedState extends AbstractEvseState {
             if (response.getIdTokenInfo().getStatus() == AuthorizationStatusEnum.ACCEPTED) {
                 evse.setToken(tokenId);
                 if (!evse.hasOngoingTransaction()) {
-                    String transactionId = TransactionIdGenerator.getInstance().getAndIncrement();
+                    String transactionId = TransactionIdGenerator.getInstance().generateTransactionId();
                     evse.createTransaction(transactionId);
 
                     stationMessageSender.sendTransactionEventStart(evseId, AUTHORIZED, tokenId);

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/WaitingForAuthorizationState.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/WaitingForAuthorizationState.java
@@ -60,7 +60,7 @@ public class WaitingForAuthorizationState extends AbstractEvseState {
             evse.setToken(tokenId);
 
             if (!evse.hasOngoingTransaction()) {
-                String transactionId = TransactionIdGenerator.getInstance().getAndIncrement();
+                String transactionId = TransactionIdGenerator.getInstance().generateTransactionId();
                 evse.createTransaction(transactionId);
 
                 stationMessageSender.sendTransactionEventStart(evseId, AUTHORIZED, tokenId);

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/WaitingForPlugState.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/evse/states/WaitingForPlugState.java
@@ -49,7 +49,7 @@ public class WaitingForPlugState extends AbstractEvseState {
             log.info("Station has authorised token {}", tokenId);
 
             if (!evse.hasOngoingTransaction()) {
-                String transactionId = TransactionIdGenerator.getInstance().getAndIncrement();
+                String transactionId = TransactionIdGenerator.getInstance().generateTransactionId();
                 evse.createTransaction(transactionId);
 
                 stationMessageSender.sendTransactionEventStart(evseId, connectorId, CABLE_PLUGGED_IN, ChargingStateEnum.EV_CONNECTED);

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/schedulers/MeterValuesSenderTask.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/schedulers/MeterValuesSenderTask.java
@@ -39,7 +39,7 @@ public class MeterValuesSenderTask implements Runnable {
             LocalDateTime now = LocalDateTime.now();
             for (Evse evse : stationStore.getEvses()) {
                 if (shouldSendMeterValue(now, evse.getId(), stationStore.createView())) {
-                    long powerUsed = evse.incrementPowerConsumed(powerIncreasedPerInterval);
+                    long powerUsed = evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(powerIncreasedPerInterval);
                     stationMessageSender.sendTransactionEventUpdate(evse.getId(), null, TriggerReasonEnum.METER_VALUE_PERIODIC, ChargingStateEnum.CHARGING, powerUsed);
                     timeOfLastMeterValuePerEVSE.put(evse.getId(), now);
                 }

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/TransactionIdGenerator.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/TransactionIdGenerator.java
@@ -1,5 +1,7 @@
 package com.evbox.everon.ocpp.simulator.station.support;
 
+import java.util.UUID;
+
 /**
  * Singleton that generates transaction_id. Used in the handler-classes.
  */
@@ -28,9 +30,7 @@ public final class TransactionIdGenerator {
      * @return current transaction id value
      */
     public String getAndIncrement() {
-        Integer value = transactionId.get();
-        transactionId.set(value + 1);
-        return String.format("T_%08d", value);
+        return UUID.randomUUID().toString();
     }
 
     private static final class TransactionIdGeneratorHolder {

--- a/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/TransactionIdGenerator.java
+++ b/simulator-core/src/main/java/com/evbox/everon/ocpp/simulator/station/support/TransactionIdGenerator.java
@@ -7,11 +7,6 @@ import java.util.UUID;
  */
 public final class TransactionIdGenerator {
 
-    /**
-     * Transaction id thread-local
-     */
-    private final ThreadLocal<Integer> transactionId = ThreadLocal.withInitial(() -> 1);
-
     private TransactionIdGenerator() {
     }
 
@@ -29,7 +24,7 @@ public final class TransactionIdGenerator {
      *
      * @return current transaction id value
      */
-    public String getAndIncrement() {
+    public String generateTransactionId() {
         return UUID.randomUUID().toString();
     }
 

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/it/authorization/EvDriverAuthorizationUsingRfidIt.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/it/authorization/EvDriverAuthorizationUsingRfidIt.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import static com.evbox.everon.ocpp.mock.constants.StationConstants.DEFAULT_CONNECTOR_ID;
 import static com.evbox.everon.ocpp.mock.constants.StationConstants.DEFAULT_EVSE_ID;
 import static com.evbox.everon.ocpp.mock.constants.StationConstants.DEFAULT_TOKEN_ID;
-import static com.evbox.everon.ocpp.mock.constants.StationConstants.DEFAULT_TRANSACTION_ID;
 import static com.evbox.everon.ocpp.mock.constants.StationConstants.STATION_ID;
 import static com.evbox.everon.ocpp.v20.message.ChargingStateEnum.CHARGING;
 import static com.evbox.everon.ocpp.v20.message.ChargingStateEnum.EV_CONNECTED;
@@ -38,15 +37,15 @@ public class EvDriverAuthorizationUsingRfidIt extends StationSimulatorSetUp {
                 .thenReturn(StatusNotification.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, EV_CONNECTED, CABLE_PLUGGED_IN))
+                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, EV_CONNECTED, CABLE_PLUGGED_IN))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, CHARGING, CHARGING_STATE_CHANGED))
+                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, CHARGING, CHARGING_STATE_CHANGED))
                 .thenReturn(TransactionEvent.response());
 
         stationSimulatorRunner.run();

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/it/remotecontrol/RemoteStopTransactionIt.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/it/remotecontrol/RemoteStopTransactionIt.java
@@ -41,7 +41,7 @@ public class RemoteStopTransactionIt extends StationSimulatorSetUp {
                 .thenReturn(Authorize.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(TransactionEventEnum.UPDATED, ChargingStateEnum.EV_CONNECTED, DEFAULT_TRANSACTION_ID, TriggerReasonEnum.REMOTE_STOP))
+                .when(TransactionEvent.request(TransactionEventEnum.UPDATED, ChargingStateEnum.EV_CONNECTED, TriggerReasonEnum.REMOTE_STOP))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
@@ -59,8 +59,9 @@ public class RemoteStopTransactionIt extends StationSimulatorSetUp {
         triggerUserAction(STATION_ID, new com.evbox.everon.ocpp.simulator.station.actions.user.Authorize(DEFAULT_TOKEN_ID, DEFAULT_EVSE_ID));
 
         await().untilAsserted(() -> assertThat(stationSimulatorRunner.getStation(STATION_ID).getStateView().isCharging(DEFAULT_EVSE_ID)).isTrue());
+        String transactionId = stationSimulatorRunner.getStation(STATION_ID).getStateView().getDefaultEvse().getTransaction().getTransactionId();
 
-        Call call = new Call(DEFAULT_CALL_ID, ActionType.REQUEST_STOP_TRANSACTION, new RequestStopTransactionRequest().withTransactionId(new CiString.CiString36(DEFAULT_TRANSACTION_ID)));
+        Call call = new Call(DEFAULT_CALL_ID, ActionType.REQUEST_STOP_TRANSACTION, new RequestStopTransactionRequest().withTransactionId(new CiString.CiString36(transactionId)));
         ocppServerClient.findStationSender(STATION_ID).sendMessage(call.toJson());
 
         await().untilAsserted(() -> assertThat(stationSimulatorRunner.getStation(STATION_ID).getStateView().isCharging(DEFAULT_EVSE_ID)).isFalse());

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/StartTransactionCablePluginFirstIt.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/StartTransactionCablePluginFirstIt.java
@@ -26,7 +26,7 @@ public class StartTransactionCablePluginFirstIt extends StationSimulatorSetUp {
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(STARTED, DEFAULT_SEQ_NUMBER, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(STARTED, DEFAULT_SEQ_NUMBER, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         stationSimulatorRunner.run();

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/StartTransactionIdTokenFirstIt.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/StartTransactionIdTokenFirstIt.java
@@ -38,15 +38,15 @@ public class StartTransactionIdTokenFirstIt extends StationSimulatorSetUp {
                 .thenReturn(StatusNotification.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, EV_CONNECTED, CABLE_PLUGGED_IN))
+                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, EV_CONNECTED, CABLE_PLUGGED_IN))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, CHARGING, CHARGING_STATE_CHANGED))
+                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_EVSE_ID, DEFAULT_TOKEN_ID, CHARGING, CHARGING_STATE_CHANGED))
                 .thenReturn(TransactionEvent.response());
 
         stationSimulatorRunner.run();

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/TransactionLocallyStoppedByIdTokenIt.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/TransactionLocallyStoppedByIdTokenIt.java
@@ -35,15 +35,15 @@ public class TransactionLocallyStoppedByIdTokenIt extends StationSimulatorSetUp 
                 .thenReturn(StatusNotification.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         stationSimulatorRunner.run();

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/WhenCableDisconnectedOnEvSideStopTransactionIt.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/it/transactions/WhenCableDisconnectedOnEvSideStopTransactionIt.java
@@ -37,19 +37,19 @@ public class WhenCableDisconnectedOnEvSideStopTransactionIt extends StationSimul
                 .thenReturn(StatusNotification.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(UPDATED, seqNo + 1, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(UPDATED, seqNo + 2, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(ENDED, seqNo + 3, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(ENDED, seqNo + 3, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         stationSimulatorRunner.run();
@@ -86,11 +86,11 @@ public class WhenCableDisconnectedOnEvSideStopTransactionIt extends StationSimul
                 .thenReturn(StatusNotification.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(STARTED, seqNo, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         ocppMockServer
-                .when(TransactionEvent.request(ENDED, seqNo + 3, DEFAULT_TRANSACTION_ID, DEFAULT_EVSE_ID))
+                .when(TransactionEvent.request(ENDED, seqNo + 3, DEFAULT_EVSE_ID))
                 .thenReturn(TransactionEvent.response());
 
         stationSimulatorRunner.run();

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/mock/StationSimulatorSetUp.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/mock/StationSimulatorSetUp.java
@@ -53,8 +53,8 @@ public class StationSimulatorSetUp  {
 
         StationConfiguration stationConfiguration = SimulatorConfigCreator.createStationConfiguration(STATION_ID, DEFAULT_EVSE_COUNT, DEFAULT_EVSE_CONNECTORS, getMeterValuesConfiguration());
         stationConfiguration.getComponentsConfiguration().getTxCtrlr().setEvConnectionTimeOutSec(getEVConnectionTimeOutSec());
-        stationConfiguration.getComponentsConfiguration().getTxCtrlr().setTxStartPoints(txStartStopPoints);
-        stationConfiguration.getComponentsConfiguration().getTxCtrlr().setTxStopPoints(txStartStopPoints);
+        stationConfiguration.getComponentsConfiguration().getTxCtrlr().setTxStartPoint(txStartStopPoints);
+        stationConfiguration.getComponentsConfiguration().getTxCtrlr().setTxStopPoint(txStartStopPoints);
 
         SimulatorConfiguration simulatorConfiguration = SimulatorConfigCreator.createSimulatorConfiguration(stationConfiguration);
 

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/mock/constants/VariableConstants.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/mock/constants/VariableConstants.java
@@ -9,7 +9,7 @@ public class VariableConstants {
 
     // variable names
     public static final String BASIC_AUTH_PASSWORD_VARIABLE_NAME = "BasicAuthPassword";
-    public static final String TX_START_POINT_VARIABLE_NAME = "TxStartPoints";
-    public static final String TX_STOP_POINT_VARIABLE_NAME = "TxStopPoints";
+    public static final String TX_START_POINT_VARIABLE_NAME = "TxStartPoint";
+    public static final String TX_STOP_POINT_VARIABLE_NAME = "TxStopPoint";
     public static final String NETWORK_CONFIGURATION_PRIORITY_VARIABLE_NAME = "NetworkConfigurationPriority";
 }

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/mock/csms/exchange/TransactionEvent.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/mock/csms/exchange/TransactionEvent.java
@@ -53,15 +53,14 @@ public class TransactionEvent {
      *
      * @param type          transaction type
      * @param chargingState charging state
-     * @param transactionId id of the transaction
      * @param triggerReason trigger reason
      * @return checks whether an incoming request is TransactionEvent or not.
      */
-    public static Predicate<Call> request(TransactionEventEnum type, ChargingStateEnum chargingState, String transactionId, TriggerReasonEnum triggerReason) {
+    public static Predicate<Call> request(TransactionEventEnum type, ChargingStateEnum chargingState, TriggerReasonEnum triggerReason) {
         return request -> equalsType(request, TRANSACTION_EVENT) &&
                 equalsEventType(request, type) &&
                 equalsChargingState(request, chargingState) &&
-                equalsTransactionId(request, transactionId) &&
+                notNullTransactionId(request) &&
                 equalsTriggerReason(request, triggerReason);
     }
 
@@ -70,15 +69,14 @@ public class TransactionEvent {
      *
      * @param type          transaction type
      * @param seqNo         sequence number
-     * @param transactionId id of the transaction
      * @param evseId        evse id
      * @return checks whether an incoming request is TransactionEvent or not.
      */
-    public static Predicate<Call> request(TransactionEventEnum type, int seqNo, String transactionId, int evseId) {
+    public static Predicate<Call> request(TransactionEventEnum type, int seqNo, int evseId) {
         return request -> equalsType(request, TRANSACTION_EVENT) &&
                 equalsEventType(request, type) &&
                 equalsSeqNo(request, seqNo) &&
-                equalsTransactionId(request, transactionId) &&
+                notNullTransactionId(request) &&
                 equalsEvseId(request, evseId);
     }
 
@@ -99,6 +97,35 @@ public class TransactionEvent {
                 equalsTransactionId(request, transactionId) &&
                 equalsEvseId(request, evseId) &&
                 equalsTokenId(request, tokenId);
+    }
+
+    /**
+     * Transaction event with given configuration.
+     *
+     * @param type          transaction type
+     * @param seqNo         sequence number
+     * @param evseId        evse id
+     * @param tokenId       id of the auth token
+     * @param chargingState charging satte
+     * @param triggerReason trigger reason for the event
+     * @return checks whether an incoming request is TransactionEvent or not.
+     */
+    public static Predicate<Call> request(
+            TransactionEventEnum type,
+            int seqNo,
+            int evseId,
+            String tokenId,
+            ChargingStateEnum chargingState,
+            TriggerReasonEnum triggerReason) {
+
+        return request -> equalsType(request, TRANSACTION_EVENT) &&
+                equalsEventType(request, type) &&
+                equalsSeqNo(request, seqNo) &&
+                notNullTransactionId(request) &&
+                equalsEvseId(request, evseId) &&
+                equalsTokenId(request, tokenId) &&
+                equalsChargingState(request, chargingState) &&
+                equalsTriggerReason(request, triggerReason);
     }
 
     /**
@@ -151,6 +178,10 @@ public class TransactionEvent {
 
     private static boolean equalsTransactionId(Call request, String transactionId) {
         return ((TransactionEventRequest) request.getPayload()).getTransactionInfo().getTransactionId().toString().equals(transactionId);
+    }
+
+    private static boolean notNullTransactionId(Call request) {
+        return ((TransactionEventRequest) request.getPayload()).getTransactionInfo().getTransactionId() != null;
     }
 
     private static boolean equalsEvseId(Call request, int evseId) {

--- a/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/station/evse/EvseTest.java
+++ b/simulator-core/src/test/java/com/evbox/everon/ocpp/simulator/station/evse/EvseTest.java
@@ -34,7 +34,7 @@ class EvseTest {
 
         long incrementValue = 1000;
         for (int i = 1; i < 20; i++) {
-            long incrementedValue = evse.incrementPowerConsumed(incrementValue);
+            long incrementedValue = evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(incrementValue);
             assertThat(incrementedValue).isEqualTo(incrementValue * i);
             assertThat(evse.getTotalConsumedWattHours()).isEqualTo(incrementValue * i);
         }
@@ -46,11 +46,11 @@ class EvseTest {
         assertThat(startingPowerConsumed).isEqualTo(0);
 
         long incrementValue = Long.MAX_VALUE - 150;
-        assertThat(evse.incrementPowerConsumed(incrementValue)).isEqualTo(incrementValue);
-        assertThat(evse.incrementPowerConsumed(100)).isEqualTo(incrementValue + 100);
+        assertThat(evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(incrementValue)).isEqualTo(incrementValue);
+        assertThat(evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(100)).isEqualTo(incrementValue + 100);
 
         // The counter starts from zero and zero is counted as a value, that's why it is 49 and not 50
-        assertThat(evse.incrementPowerConsumed(100)).isEqualTo(49);
+        assertThat(evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(100)).isEqualTo(49);
     }
 
     @Test
@@ -59,16 +59,16 @@ class EvseTest {
         assertThat(startingPowerConsumed).isEqualTo(0);
 
         long startingValue = Long.MAX_VALUE - 10;
-        assertThat(evse.incrementPowerConsumed(startingValue)).isEqualTo(startingValue);
+        assertThat(evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(startingValue)).isEqualTo(startingValue);
 
         for (int i = 1; i <= 10; i++) {
-            assertThat(evse.incrementPowerConsumed(1)).isEqualTo(startingValue + i);
+            assertThat(evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(1)).isEqualTo(startingValue + i);
         }
 
         assertThat(evse.getTotalConsumedWattHours()).isEqualTo(Long.MAX_VALUE);
 
         for (int i = 0; i <= 10; i++) {
-            assertThat(evse.incrementPowerConsumed(1)).isEqualTo(i);
+            assertThat(evse.incrementPowerConsumedAndGetUsedPowerForCurrentCharging(1)).isEqualTo(i);
         }
     }
 


### PR DESCRIPTION
DONE:
- update TxStartPoints & TxStopPoints config variables -> changed to TxStartPoint & TxStopPoint
- send proper 'wattConsumedLastSession' at the end of transaction
- change message order on connector unplug action after remote stop (end transaction -> send info about connector status)
- use UUID as transactionID